### PR TITLE
Fix TypeError: (intermediate value).map is not a function

### DIFF
--- a/src/components/Repositories/RepairRepository.js
+++ b/src/components/Repositories/RepairRepository.js
@@ -6,7 +6,7 @@ import apiCall from '../../utils/apiCall';
 export class RepairRepository {
   static async getAll() {
     const data = await apiCall(config.server, '/api/repairs', 'GET');
-    return data.map((repair) => new Repair(repair));
+    return new Repair(data);
   }
 
   static async getStats() {


### PR DESCRIPTION
The application has a runtime error: 
TypeError: (intermediate value).map is not a function. `data` contains a json object, which does not support .map() method.